### PR TITLE
reload macros when configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ MIT
 
 ## Known Issues
 
-Doesn't currently add macros to command pallete (have to use keybindings)
-
-You currently have to reload the VS Code window after making a change to your macros.
+Doesn't currently add macros to command pallete (have to use keybindings).
 
 
 ## Release Notes

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,24 @@
 const vscode = require('vscode');
 const PromiseSeries = require('promise-series');
 
+var activeContext;
+var disposables = [];
+
 function activate(context) {
+  loadMacros(context);
+  activeContext = context;
+  vscode.workspace.onDidChangeConfiguration(() => {
+    disposeMacros();
+    loadMacros(activeContext);
+  });
+}
+exports.activate = activate;
+
+function deactivate() {
+}
+exports.deactivate = deactivate;
+
+function loadMacros(context) {
   const settings = vscode.workspace.getConfiguration('macros');
   const macros = Object.keys(settings).filter((prop) => {
     return prop !== 'has' && prop !== 'get' && prop !== 'update';
@@ -18,10 +35,12 @@ function activate(context) {
       return series.run();
     })
     context.subscriptions.push(disposable);
-  })
+    disposables.push(disposable);
+  });
 }
-exports.activate = activate;
 
-function deactivate() {
+function disposeMacros() {
+  for (var disposable of disposables) {
+    disposable.dispose();
+  }
 }
-exports.deactivate = deactivate;


### PR DESCRIPTION
Solves Issue #2
I basically moved the functionality from the activate function to a loadMacros function which is called in vscode.workspace.onDidChangeConfiguration after desposing existing macro commands. 
Tested under Windows 10.