### PR TITLE
Custom delay command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -18,8 +18,7 @@ exports.deactivate = deactivate;
 
 function executeDelayCommand(action) {
   return new Promise(resolve => {
-    const milliseconds = Array.isArray(action.args) ? action.args[0] : 0;
-    setTimeout(() => resolve(), milliseconds);
+    setTimeout(() => resolve(), action.args && action.args.milliseconds);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
         "eslint": "^3.6.0",
         "@types/node": "^6.0.40",
         "@types/mocha": "^2.2.32"
-    },
-    "dependencies": {
-        "promise-series": "^1.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Macros configuration"
+            "title": "Macros configuration",
+            "properties": {
+                "macros": {
+                    "type": "object",
+                    "description": "The root element to define macros in."
+                }
+            }
         }
     },
     "scripts": {


### PR DESCRIPTION
This solved a specific problem I was having, and since there was discussion in #9 about delays, I figured this might be generally useful.

Specifically, this adds `$delay` as a command (taking one argument, the delay length in milliseconds), e.g.

```json
"macros": {
  "addSemicolon": [
    "cursorEnd",
    {"command": "$delay", "args": {"milliseconds": 1000}},
    {"command": "type", "args": {"text": ";"}}
  ]
}
```

I also fixed #5, incidentally solved the same problem as in PR #11, and removed the dependency on `promise-series` (I was having a harder time following the code with it in there and it didn't seem necessary).